### PR TITLE
Rework: Feature/#8315 update usergroup endpoint

### DIFF
--- a/source/includes/api/core/_user_groups.md
+++ b/source/includes/api/core/_user_groups.md
@@ -140,18 +140,6 @@ image_url | `string` | a url of user group image
 This endpoint updates a specific user_group associated to an api keys programme. Please note that attempting to change a `user_group`'s `default`, will
 result in an error.
 
-#### Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-name | `string` |  Name of the user_group
-position | `integer` | Position of the user_group in the hierachy
-parent_id | `integer` | ID of a user_group that this user_group should be nested underneath. Providing an invalid ID will result in an error.
-image_url | `string` | A url of the user_group image
-
-#### HTTP Request
-
-`PUT /api/v2/user_groups/{user_group_id}`
 
 > Request:
 ``` http
@@ -179,4 +167,44 @@ HTTP/1.1 200 OK
   "default": false,
   "image_url": "http://example_hosted_image_url.com/image.png"
 }
+```
+#### HTTP Request
+
+`PUT /api/v2/user_groups/{user_group_id}`
+#### Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+name | `string` |  Name of the user_group
+position | `integer` | Position of the user_group in the hierachy
+parent_id | `integer` | ID of a user_group that this user_group should be nested underneath. Providing an invalid ID will result in an error.
+image_url | `string` | A url of the user_group image
+
+### Delete a User Group
+
+This endpoint deletes a specific user group associated to an api keys programme. You can only delete user groups that have no associated users or user groups, and are not the default user group. Any attempt to do so will result in an error.
+
+#### Path Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+user_group_id | `integer` | The ID of the user group you want to delete
+
+#### HTTP Request
+
+`DELETE /api/v2/user_groups/{user_group_id}`
+
+> Request:
+
+``` http
+DELETE /api/v2/user_groups/{user_group_id} HTTP/1.1
+Authorization: Token token=xxx
+Content-Type: application/json
+```
+
+> Response:
+
+``` http
+HTTP/1.1 200 OK
+No content
 ```


### PR DESCRIPTION
Connects [8315](https://github.com/CorporateRewards/myrewards/issues/8315)

This is to fix an issue whereby the update a user group section is not displaying as intended.
This is how it is currently displayed:
![image](https://user-images.githubusercontent.com/42269951/153243101-b316c91e-a6e7-4559-a686-49857b860279.png)


