### PR TITLE
Rework: Feature/#8315 update usergroup endpoint

### DIFF
--- a/source/includes/api/core/_transactions.md
+++ b/source/includes/api/core/_transactions.md
@@ -128,9 +128,8 @@ A points transaction will also have a variety which will be one of:
 
 Variety | Programme Points affecting? | Permitted Type
 ------- | --------------------------- | --------------
-Programme points | Yes | Credit or debit
+Programme points | Yes | Credit only
 Points Error | Yes | Debit only
-Redemption | No | Debit only
 Person2Person transfer | Yes | Credit or debit (credit and debit must both be carried out for each user)
 Order Cancellation | No | Credit only
 Order Adjustment | No | Credit or debit

--- a/source/includes/api/core/_user_groups.md
+++ b/source/includes/api/core/_user_groups.md
@@ -141,6 +141,8 @@ image_url | `string` | a url of user group image
 This endpoint updates a specific user_group associated to an api keys programme. Please note that attempting to change a `user_group`'s `default`, will
 result in an error.
 
+> Request:
+
 ``` http
 PUT /api/v2/user_groups/{user_group_id} HTTP/1.1
 Authorization: Token token=xxx
@@ -153,8 +155,11 @@ Content-Type: application/json
 
 ```
 
+> Response:
+
 ``` http
 HTTP/1.1 200 OK
+Content-Type: application/json
 
 {
   "id" : 1,
@@ -166,9 +171,11 @@ HTTP/1.1 200 OK
   "image_url": "http://example_hosted_image_url.com/image.png"
 }
 ```
+
 #### HTTP Request
 
 `PUT /api/v2/user_groups/{user_group_id}`
+
 #### Attributes
 
 Attribute | Type | Description

--- a/source/includes/api/core/_user_groups.md
+++ b/source/includes/api/core/_user_groups.md
@@ -141,8 +141,6 @@ image_url | `string` | a url of user group image
 This endpoint updates a specific user_group associated to an api keys programme. Please note that attempting to change a `user_group`'s `default`, will
 result in an error.
 
-
-> Request:
 ``` http
 PUT /api/v2/user_groups/{user_group_id} HTTP/1.1
 Authorization: Token token=xxx
@@ -155,7 +153,6 @@ Content-Type: application/json
 
 ```
 
-> Response:
 ``` http
 HTTP/1.1 200 OK
 


### PR DESCRIPTION
I still seem to have a problem with the layout of update user group. This PR attempts to fix that. The screenshot below is how the 'Update user group section' appear for me locally.

![image](https://user-images.githubusercontent.com/42269951/153914251-ea9ebb53-c966-4ef9-adcc-76d2fe2049dd.png)

I have also made a small change within this PR to remove 'Redemption' from 'Create a Transaction' and change programme points to be credit only.