### PR TITLE
change/#122-user-lookup-documentation

### DIFF
--- a/source/includes/api/core/_users.md
+++ b/source/includes/api/core/_users.md
@@ -179,10 +179,7 @@ marketing_consented | `boolean` | Can be true or false, not required if programm
 
 ### Get a User
 
-This endpoint returns a specific user associated with an api key's programme.<br />
-You have the option to specify either the user's unique MyRewards ID, email address, or the username.<br />
-<br />
-<i><strong>Please note:</strong> you can only specify one of the parameters at a time.</i>
+This endpoint returns a specific user associated with an api key's programme. You have the option to specify either the user's unique MyRewards ID, email address, or the username.
 
 #### Path Parameters
 
@@ -197,14 +194,13 @@ username | `string` | The username of the user to return
 variations of the request that are supported:
 
 - `GET /api/v3/users/{id}`
-- `GET /api/v3/users?id={id}`
-- `GET /api/v3/users?email={email}`
-- `GET /api/v3/users?username={username}`
+- `GET /api/v3/users/email/{email}`
+- `GET /api/v3/users/username/{username}`
 
 > Request:
 
 ``` http
-GET /api/v3/users?id={id} HTTP/1.1
+GET /api/v3/users/{id} HTTP/1.1
 Authorization: Token token=xxx
 Content-Type: application/json
 ```

--- a/source/includes/api/core/_users.md
+++ b/source/includes/api/core/_users.md
@@ -179,23 +179,33 @@ marketing_consented | `boolean` | Can be true or false, not required if programm
 
 ### Get a User
 
-This endpoint returns a specific user associated to an api keys programme.
+This endpoint returns a specific user associated with an api key's programme.<br />
+You have the option to specify either the user's unique MyRewards ID, email address, or the username.<br />
+<br />
+<i><strong>Please note:</strong> you can only specify one of the parameters at a time.</i>
 
 #### Path Parameters
 
 Parameter | Type | Description
 --------- | ---- | -----------
-user_id | `integer` | The ID of the user you want to return
+id | `integer` | The unique MyRewards ID of the user to return
+email | `string` | The email address of the user to return
+username | `string` | The username of the user to return
 
 #### HTTP Request
 
-`GET /api/v3/users/{user_id}`
+variations of the request that are supported:
+
+- `GET /api/v3/users/{id}`
+- `GET /api/v3/users?id={id}`
+- `GET /api/v3/users?email={email}`
+- `GET /api/v3/users?username={username}`
 
 > Request:
 
 ``` http
-GET /api/v3/users/681 HTTP/1.1
-Authorization: Token token={key}:{secret}
+GET /api/v3/users?id={id} HTTP/1.1
+Authorization: Token token=xxx
 Content-Type: application/json
 ```
 


### PR DESCRIPTION
change/#122-user-lookup-documentation (bca05e8)
- updated users v3 get documentation to include information about parameter lookups
- connects #122

change/#122-user-lookup-documentation (db6c30e)
- updated v3 user get documentation
    - supports path /api/v3/users/{id} (original)
    - supports path /api/v3/users/email/{email}
    - supports path /api/v3/users/username/{username}
- removed unnecessary warnings
- connects #122