### PR TITLE
change/#127-remove-staging-reference

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -48,16 +48,15 @@ search: true
 # Introduction
 Welcome to the MyRewards API documentation.
 
-The first thing you will have to find out is the correct API endpoint to use for
-the right environment.
+Your 360insights project manager / customer success manager will share the API authentication details for your production site.
 
-- **Staging:** [https://staging.my-rewards.co.uk](https://staging.my-rewards.co.uk)
-- For production access please ask your MyRewards contact
+If you require a separate instance for testing and development purposes, please discuss this requirement with your 360insights project manager / customer success manager.
+
+Access to the development build of MyRewards for upcoming features will only be granted on a discretionary basis.
 
 A programme can have one or more API keys, each of which will be granted
 permission to access different functionality from the API. As a standard, we use
-RESTful json endpoints that will accept either HTML/HTTP form data or json data,
-HTML/HTTP is preferred.
+RESTful json endpoints that will accept either HTML/HTTP form data or json data.
 
 # Authentication
 


### PR DESCRIPTION
change/#127-remove-staging-reference (0811271)
- removed reference to staging platform url
    - 360insights does not offer access to staging (dev) as it's technically always different to production; instead we should only ever offer clones of client sites for testing purposes, which typically come at a cost.
    - added a message to indicate that staging (dev) access is only granted on a discretionary basis (typically only to test new upcoming features)
    - additional message to instruct clients to discuss the creation of testing environments if required
- removed reference to the "preferred" method, as it was likely eluding to form-data being the preferred payload; however we've no examples of form-data payloads
- resolves #127