### PR TITLE
spelling correction

### DIFF
--- a/source/includes/sso/_saml.md
+++ b/source/includes/sso/_saml.md
@@ -307,7 +307,7 @@ The following standard user fields may be provided as an attributes Name value e
 If your programme uses a free text company question, then you may just send this as "company" as above, however, if your programme has a managed list of companies, then you must provide the users company details differently and we expect both of the below:
 
 * company_name
-* company_identifer
+* company_identifier
 
 
 #### Custom registration questions


### PR DESCRIPTION
[2024-02-01T22:01:13+00:00] spelling-correction (ecc6d85)
- corrected the spelling of `company_identifier`
    - previously `company_identifer`