### PR TITLE
Add info that reward_point quantity must be 1 if returns are enabled

### DIFF
--- a/source/includes/api/performance/_reward_points.md
+++ b/source/includes/api/performance/_reward_points.md
@@ -156,7 +156,7 @@ Parameter | Type | Description
 --------- | ---- | -----------
 reference | string | Required. Ref of the [performance product](#performance-module-performance-products) that the reward point is to be claimed against.
 user_group_ids | array | Optional. An array of all of the user groups that should be eligible for the reward point.
-quantity | integer | Required. The quantity that must be claimed to qualify for the reward point.
+quantity | integer | Required. The quantity that must be claimed to qualify for the reward point. This must be 1 if returns are enabled on your promotion.
 points_per_quantity | integer | Required. The number of points to award per quantity.
 date_from | date | Required. The date the reward point is eligible from.
 date_to | date | Required. The date the reward point is eligible to.
@@ -229,7 +229,7 @@ id | `integer` |  Required. The ID of the reward point to update.
 Parameter | Type | Description
 --------- | ---- | -----------
 user_group_ids | array | An array of all of the user groups that should be eligible for the reward point.
-quantity | integer | The quantity that must be claimed to qualify for the reward point.
+quantity | integer | The quantity that must be claimed to qualify for the reward point. This must be 1 if returns are enabled on your promotion.
 points_per_quantity | integer | The number of points to award per quantity.
 date_from | date | The date the reward point is eligible from.
 date_to | date | The date the reward point is eligible to.


### PR DESCRIPTION
This relates to https://github.com/CorporateRewards/myrewards/pull/9922.