### PR TITLE
TSI-1111-Fix-Docker-Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,18 @@ Each section should contain the following elements in this order:
   - H5 (#####) URL Parameters
   - H5 (#####) Body Parameters
 - H4 (####) Response Parameters
- 
 
+## Testing Locally
+
+### Requirements
+- Git
+- Docker with compose
+
+### Steps
+1. Clone the repo.
+2. Run `docker compose build` at least once to build the images.
+3. Run `docker compose up` to start the slate instance container.
+4. Visit `http://localhost/` in your browser.
+5. Make changes to the markdown files in the `source` folder.
+6. Refresh the browser to see the changes.
+7. When done, run `docker compose down` to stop the container.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Adding an end-point
 - create a file in `/includes/api/{module}`
-- use the structure, language and style from `/includes/example/_kittens.md` 
+- use the structure, language and style from `/includes/example/_kittens.md`
 - add the file to `includes:` section of `index.html.md` (alphabetically)
 
 Once the changes have been made, create a PR to master. When the PR is merged, GitHub Actions will pickup the changes and deploy.
@@ -24,13 +24,13 @@ Each section should contain the following elements in this order:
 
 - `> Header:`
 - `> Body:` (POST only)
-- `> Response:` 
+- `> Response:`
 - Description of the end point
 - H4 (####) HTTP Request
 - GET/POST/DELETE
-- H4 (####) Request Parameters 
+- H4 (####) Request Parameters
   - _if there are URL and Body params, then create two more sections:_
-  - H5 (#####) URL Parameters 
+  - H5 (#####) URL Parameters
   - H5 (#####) Body Parameters
 - H4 (####) Response Parameters
  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,16 @@
----
-version: '3'
 services:
+
   slate:
     build:
-      context: .
+      context: ./
     volumes:
-      - .:/srv/slate
+      - ./:/srv/slate/
     ports:
-      - 4567:4567
-    command: sh -c '
-      bundle install &&
-      if [ "$BYEBUG" -eq "1" ];
-        then echo "sleeping";
-        sleep 100d;
-      else
-        bundle exec middleman server;
-      fi
-      '
+      - 80:4567
+    entrypoint: >-
+      /usr/bin/env bash -e -c
+    command:
+      - >-
+        bundle install &&
+        /srv/slate/slate.sh build &&
+        /srv/slate/slate.sh serve;


### PR DESCRIPTION
Addressed an issue with docker compose recipe and updated readme with instructions for testing locally.

---

Ref: TSI-1111

<details>
<summary id='change-log'>Change Log</summary>

🔬 [Compare](https://github.com/CorporateRewards/docs-myrewards/compare/68a9387c60edb3be0aa7f02e40a394e6c0d5eb1c..427660c12cfda8537f6c4f2db021106ed232326d)

(ae20de3a36662a1b80f5a12331879dadd6a649e2) [2026-02-04T00:21:38+0000] fix: 🔧 address entrypoint and command issue
- The default entry point for this build was the slate script; consequently any shell commands passed into this script caused it to hang.
- By overriding the default entry point to bash, we can instead pass shell commands to perform all the desired steps.
- ref: TSI-1111

(c6068692b04e6d1e74f29091ee30efa7ae1c3cd6) [2026-02-04T00:22:16+0000] style: 🎨 improve formatting in README for consistency
- ref: TSI-1111

(427660c12cfda8537f6c4f2db021106ed232326d) [2026-02-04T00:22:27+0000] docs: 📝 add local testing instructions to README
- ref: TSI-1111

</details>