### PR TITLE
TSI-1111-Correct-User-Permissions-Doc

### DIFF
--- a/source/includes/api/core/_users_permissions.md
+++ b/source/includes/api/core/_users_permissions.md
@@ -51,7 +51,7 @@ active | string | Required indicates if this permission is active for this user
 state | string | Required indicates whether the permission is granted or denied specifically for this user or if it is the same as the user_group
 
 
-### POST User permissions
+### PATCH User permissions
 
 A endpoint to update a list of permissions for a given user. Returns an array of permissions displaying it's parent
 permissions group name. This is to help identify different permissions when names are the same across separate groups.
@@ -59,7 +59,7 @@ It will also display whether the permission is active for the given user and the
 be `Same As User Group` or if the permission has been overridden for that user: `Always Allow` or `Always Deny`.
 
 The only value that this request will change is the `active` field. The other fields are present
-to make it easier to move from the `GET` request to a `POST` without having to reformat
+to make it easier to move from the `GET` request to a `PATCH` without having to reformat
 or delete much of the `GET` request response.
 
 N.B. When specifying active = true this will set the permission to "Always allow"

--- a/source/stylesheets/_custom.scss
+++ b/source/stylesheets/_custom.scss
@@ -31,3 +31,9 @@
     font-size: 13px;
   }
 }
+
+.content code {
+  // prevent word and line breaking in code blocks
+  word-break: keep-all !important;
+  white-space: pre !important;
+}


### PR DESCRIPTION
Correct endpoint method from POST to PATCH for user permissions

---

🔬 Compare: [ab887dc..532cc59](https://github.com/CorporateRewards/docs-myrewards/compare/ab887dc867cd7767100d75d485e8eb0c886ccc8f..532cc5970bf001f9395980c0d81489ab38d4acf6)
🔗 Ref: TSI-1111

<details>
<summary id='change-log'>Change Log</summary>

(b07b51fb2219961ad09c24d8c10ea3e718e9b4b2) [2026-04-23T14:21:37+0100] fix: 🔧 correct endpoint method from POST to PATCH for user permissions

(696deb8412ed19ff389f49a5dbab89df56b5a5e4) [2026-04-23T14:51:51+0100] style: 🎨 add CSS rules to prevent word and line breaking in code blocks

(7ea595198d418b53dd31a04bc8ba4a7df2b310a4) [2026-07-07T17:46:48+0100] docs: 📝 fix typo in PATCH User permissions section

(532cc5970bf001f9395980c0d81489ab38d4acf6) [2026-07-07T17:46:55+0100] style: 🎨 refine CSS selector for code blocks to prevent word and line breaking in descriptions

</details>